### PR TITLE
add `loading="lazy"` attributes to image tag

### DIFF
--- a/src/lib/components/AvatarImg.svelte
+++ b/src/lib/components/AvatarImg.svelte
@@ -6,4 +6,4 @@
 	export let style = '';
 </script>
 
-<img {src} {alt} {width} {height} {style} />
+<img {src} {alt} {width} {height} {style} loading="lazy" />

--- a/src/lib/components/MediaImg.svelte
+++ b/src/lib/components/MediaImg.svelte
@@ -5,4 +5,4 @@
     export let draggable: boolean = false;
 </script>
 
-<img src={src} alt={alt} class={className} draggable={draggable} />
+<img src={src} alt={alt} class={className} draggable={draggable} loading="lazy" />

--- a/src/lib/components/TweetMedia.svelte
+++ b/src/lib/components/TweetMedia.svelte
@@ -50,7 +50,7 @@
 					rel="noopener noreferrer"
 				>
 					<div class="skeleton" style={getSkeletonStyle(media, length)} />
-					<Img src={getMediaUrl(media, 'small')} alt={media.ext_alt_text || 'Image'} draggable />
+					<Img src={getMediaUrl(media, 'small')} alt={media.ext_alt_text || 'Image'} draggable loading="lazy"/>
 				</a>
 			{:else}
 				<div class="mediaContainer">


### PR DESCRIPTION
because loadin icons of Tweets cards decrease the score of PageSpeed Insights, I'd like to add the `loading="lazy"` attribute to each image tag.
